### PR TITLE
Account for dark theme

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -18,7 +18,7 @@ export const styles = css`
       }
 
       div.list-item:hover {
-        background: var(--paper-grey-200);
+        filter: contrast(0.85);
       }
 
       div.list-item-icon {


### PR DESCRIPTION
Use filter instead of setting the background to grey, so it doesn't turn unusable in dark mode.