### PR TITLE
Fix bug where no entites displayed if no friendly name

### DIFF
--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -1,11 +1,40 @@
+import {
+  defaults,
+  forEach,
+  each,
+  find,
+  has,
+  pick,
+  omit,
+  filter,
+  flatten,
+  map,
+  mapValues,
+  keyBy,
+  pickBy,
+  sortBy
+} from "lodash-es";
 
-import { defaults, forEach, each, find, has, pick, omit, filter, flatten, map, mapValues, keyBy, pickBy, sortBy } from "lodash-es";
-
-import { IDictionary, IEntityConfigEntry, IGroupConfigEntry, IButtonEntry, IActionConfigEntry, IConfig } from './types'
-import { defaultDomainConfig, getIconForDomain, getIconForAction, getNameForDomain, getNameForService } from './default-config'
-import { getDomainFromEntityId, CreateSlug, IsSchedulerEntity } from './helpers'
-
-
+import {
+  IDictionary,
+  IEntityConfigEntry,
+  IGroupConfigEntry,
+  IButtonEntry,
+  IActionConfigEntry,
+  IConfig
+} from "./types";
+import {
+  defaultDomainConfig,
+  getIconForDomain,
+  getIconForAction,
+  getNameForDomain,
+  getNameForService
+} from "./default-config";
+import {
+  getDomainFromEntityId,
+  CreateSlug,
+  IsSchedulerEntity
+} from "./helpers";
 
 export class Config {
   public entities: IDictionary<IEntityConfigEntry>;
@@ -19,14 +48,23 @@ export class Config {
     this.entities = {};
     this.groups = {};
 
-    if (!userConfig['entities'] && !userConfig['domains'] && (userConfig.standardConfiguration === undefined || userConfig.standardConfiguration)) this.userConfig = { domains: defaultDomainConfig };
+    if (
+      !userConfig["entities"] &&
+      !userConfig["domains"] &&
+      (userConfig.standardConfiguration === undefined ||
+        userConfig.standardConfiguration)
+    )
+      this.userConfig = { domains: defaultDomainConfig };
     else this.userConfig = userConfig;
 
     if (userConfig.groups) {
       each(userConfig.groups, this.CreateGroup.bind(this));
     }
 
-    this.discoverExisting = (userConfig.discoverExisting !== undefined) ? userConfig.discoverExisting : true;
+    this.discoverExisting =
+      userConfig.discoverExisting !== undefined
+        ? userConfig.discoverExisting
+        : true;
   }
 
   CreateGroup(cfg: object, id: string) {
@@ -35,7 +73,7 @@ export class Config {
     defaults(data, {
       name: getNameForDomain(id),
       domains: [],
-      entities: [],
+      entities: []
     });
     this.groups[id] = data;
   }
@@ -58,27 +96,34 @@ export class Config {
   AddEntityToGroup(entity_id: string) {
     let domain = getDomainFromEntityId(entity_id);
     if (this.groups[domain]) {
-      let list = [... this.groups[domain]['entities']!];
+      let list = [...this.groups[domain]["entities"]!];
       list.push(entity_id);
-      this.groups[domain]['entities'] = list;
-    }
-    else this.CreateGroup({ entities: [entity_id], icon: getIconForDomain(domain) }, domain);
+      this.groups[domain]["entities"] = list;
+    } else
+      this.CreateGroup(
+        { entities: [entity_id], icon: getIconForDomain(domain) },
+        domain
+      );
   }
 
   AddEntityInfo(entity_id: string, cfg: IEntityConfigEntry) {
     if (this.entities[entity_id]) {
-      Object.assign(this.entities[entity_id], omit({ ...cfg }, 'actions'));
-      if (has(cfg, 'actions')) {
+      Object.assign(this.entities[entity_id], omit({ ...cfg }, "actions"));
+      if (has(cfg, "actions")) {
         each(cfg.actions, action => {
-          let match = find(this.entities[entity_id]['actions'], e => { return CreateSlug(pick(e, ['service', 'service_data'])) == CreateSlug(pick(action, ['service', 'service_data'])) });
+          let match = find(this.entities[entity_id]["actions"], e => {
+            return (
+              CreateSlug(pick(e, ["service", "service_data"])) ==
+              CreateSlug(pick(action, ["service", "service_data"]))
+            );
+          });
           if (match) return;
-          let actions = [... this.entities[entity_id]['actions']];
+          let actions = [...this.entities[entity_id]["actions"]];
           actions.push(action);
-          this.entities[entity_id]['actions'] = actions;
+          this.entities[entity_id]["actions"] = actions;
         });
       }
-    }
-    else {
+    } else {
       let entry = Object.assign({ ...cfg }, { id: entity_id });
       defaults(entry, { actions: [] });
       this.entities[entity_id] = entry;
@@ -104,59 +149,74 @@ export class Config {
 
     if (this.discoverExisting) {
       let res = filter(entityList, e => IsSchedulerEntity(e.entity_id));
-      res = map(res, e => { return e.attributes['actions'] });
+      res = map(res, e => {
+        return e.attributes["actions"];
+      });
       res = flatten(res);
       each(res, item => {
-        let config = { ...item }
-        if (!getDomainFromEntityId(config['entity'])) {
-          config['entity'] = getDomainFromEntityId(config['service']) + "." + config['entity'];
-          config['service'] = config['service'].split('.').pop();
+        let config = { ...item };
+        if (!getDomainFromEntityId(config["entity"])) {
+          config["entity"] =
+            getDomainFromEntityId(config["service"]) + "." + config["entity"];
+          config["service"] = config["service"].split(".").pop();
         }
-        let service_data = omit(config, ['entity', 'service']);
+        let service_data = omit(config, ["entity", "service"]);
         if (service_data) {
-          this.AddEntityInfo(config['entity'], {
-            actions: [{ service: config['service'], service_data: service_data }]
+          this.AddEntityInfo(config["entity"], {
+            actions: [
+              { service: config["service"], service_data: service_data }
+            ]
+          });
+        } else {
+          this.AddEntityInfo(config["entity"], {
+            actions: [pick(config, "service")]
           });
         }
-        else {
-          this.AddEntityInfo(config['entity'], {
-            actions: [pick(config, 'service')]
-          });
-        }
-      })
+      });
     }
 
     each(this.entities, (cfg, entity_id) => {
+      let name = entityList[entity_id].attributes["friendly_name"]
+        ? entityList[entity_id].attributes["friendly_name"]
+        : entityList[entity_id].attributes["deviceID"];
       defaults(cfg, {
-        name: entityList[entity_id].attributes['friendly_name'],
+        name: name,
         icon: getIconForDomain(getDomainFromEntityId(entity_id))
       });
 
       Object.assign(cfg, {
-        actions: map(cfg['actions'], action => {
+        actions: map(cfg["actions"], action => {
           let config = { ...action };
           defaults(config, {
-            name: getNameForService(action['service']),
-            icon: getIconForAction(action['service'])
+            name: getNameForService(action["service"]),
+            icon: getIconForAction(action["service"])
           });
-          Object.assign(config, { id: CreateSlug(pick(action, ['service', 'service_data'])) });
+          Object.assign(config, {
+            id: CreateSlug(pick(action, ["service", "service_data"]))
+          });
           return config;
         })
       });
     });
 
-    if (entityList['sun.sun']) {
-      this.next_sunrise = new Date(entityList['sun.sun'].attributes.next_rising);
-      this.next_sunset = new Date(entityList['sun.sun'].attributes.next_setting);
+    if (entityList["sun.sun"]) {
+      this.next_sunrise = new Date(
+        entityList["sun.sun"].attributes.next_rising
+      );
+      this.next_sunset = new Date(
+        entityList["sun.sun"].attributes.next_setting
+      );
     }
   }
 
   GetGroups(): IDictionary<IButtonEntry> {
     let output = mapValues(this.groups, el => {
-      return pick(el, ['name', 'icon']) as IButtonEntry
+      return pick(el, ["name", "icon"]) as IButtonEntry;
     });
-    each(output, (item, key) => { Object.assign(item, { key: key }) });
-    output = sortBy(output, 'name');
+    each(output, (item, key) => {
+      Object.assign(item, { key: key });
+    });
+    output = sortBy(output, "name");
     return output;
   }
 
@@ -167,17 +227,24 @@ export class Config {
       let groupCfg = this.groups[group_id];
       entities = pickBy(this.entities, (_entityCfg, entity_id) => {
         let domain = getDomainFromEntityId(entity_id);
-        if (groupCfg['domains'] && groupCfg['domains'].includes(domain)) return true;
-        else if (groupCfg['entities'] && groupCfg['entities'].includes(entity_id)) return true;
+        if (groupCfg["domains"] && groupCfg["domains"].includes(domain))
+          return true;
+        else if (
+          groupCfg["entities"] &&
+          groupCfg["entities"].includes(entity_id)
+        )
+          return true;
         else return false;
       });
     }
 
     let output = mapValues(entities, el => {
-      return pick(el, ['name', 'icon']);
+      return pick(el, ["name", "icon"]);
     });
-    each(output, (item, key) => { Object.assign(item, { key: key }) });
-    output = sortBy(output, 'name');
+    each(output, (item, key) => {
+      Object.assign(item, { key: key });
+    });
+    output = sortBy(output, "name");
     return output;
   }
 
@@ -187,13 +254,15 @@ export class Config {
 
   GetActions(entity_id: string): IDictionary<IButtonEntry> {
     let entityCfg = this.entities[entity_id];
-    let actions = keyBy(entityCfg['actions'], 'id');
+    let actions = keyBy(entityCfg["actions"], "id");
 
     let output = mapValues(actions, el => {
-      return pick(el, ['name', 'icon']) as IButtonEntry
+      return pick(el, ["name", "icon"]) as IButtonEntry;
     });
-    each(output, (item, key) => { Object.assign(item, { key: key }) });
-    output = sortBy(output, 'name');
+    each(output, (item, key) => {
+      Object.assign(item, { key: key });
+    });
+    output = sortBy(output, "name");
     return output;
   }
 
@@ -203,7 +272,5 @@ export class Config {
     let res = find(entityCfg.actions, { id: action_id });
     if (res) return res as IActionConfigEntry;
     else return null;
-
   }
-
 }

--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -1,40 +1,11 @@
-import {
-  defaults,
-  forEach,
-  each,
-  find,
-  has,
-  pick,
-  omit,
-  filter,
-  flatten,
-  map,
-  mapValues,
-  keyBy,
-  pickBy,
-  sortBy
-} from "lodash-es";
 
-import {
-  IDictionary,
-  IEntityConfigEntry,
-  IGroupConfigEntry,
-  IButtonEntry,
-  IActionConfigEntry,
-  IConfig
-} from "./types";
-import {
-  defaultDomainConfig,
-  getIconForDomain,
-  getIconForAction,
-  getNameForDomain,
-  getNameForService
-} from "./default-config";
-import {
-  getDomainFromEntityId,
-  CreateSlug,
-  IsSchedulerEntity
-} from "./helpers";
+import { defaults, forEach, each, find, has, pick, omit, filter, flatten, map, mapValues, keyBy, pickBy, sortBy } from "lodash-es";
+
+import { IDictionary, IEntityConfigEntry, IGroupConfigEntry, IButtonEntry, IActionConfigEntry, IConfig } from './types'
+import { defaultDomainConfig, getIconForDomain, getIconForAction, getNameForDomain, getNameForService } from './default-config'
+import { getDomainFromEntityId, CreateSlug, IsSchedulerEntity } from './helpers'
+
+
 
 export class Config {
   public entities: IDictionary<IEntityConfigEntry>;
@@ -48,23 +19,14 @@ export class Config {
     this.entities = {};
     this.groups = {};
 
-    if (
-      !userConfig["entities"] &&
-      !userConfig["domains"] &&
-      (userConfig.standardConfiguration === undefined ||
-        userConfig.standardConfiguration)
-    )
-      this.userConfig = { domains: defaultDomainConfig };
+    if (!userConfig['entities'] && !userConfig['domains'] && (userConfig.standardConfiguration === undefined || userConfig.standardConfiguration)) this.userConfig = { domains: defaultDomainConfig };
     else this.userConfig = userConfig;
 
     if (userConfig.groups) {
       each(userConfig.groups, this.CreateGroup.bind(this));
     }
 
-    this.discoverExisting =
-      userConfig.discoverExisting !== undefined
-        ? userConfig.discoverExisting
-        : true;
+    this.discoverExisting = (userConfig.discoverExisting !== undefined) ? userConfig.discoverExisting : true;
   }
 
   CreateGroup(cfg: object, id: string) {
@@ -73,7 +35,7 @@ export class Config {
     defaults(data, {
       name: getNameForDomain(id),
       domains: [],
-      entities: []
+      entities: [],
     });
     this.groups[id] = data;
   }
@@ -96,34 +58,27 @@ export class Config {
   AddEntityToGroup(entity_id: string) {
     let domain = getDomainFromEntityId(entity_id);
     if (this.groups[domain]) {
-      let list = [...this.groups[domain]["entities"]!];
+      let list = [... this.groups[domain]['entities']!];
       list.push(entity_id);
-      this.groups[domain]["entities"] = list;
-    } else
-      this.CreateGroup(
-        { entities: [entity_id], icon: getIconForDomain(domain) },
-        domain
-      );
+      this.groups[domain]['entities'] = list;
+    }
+    else this.CreateGroup({ entities: [entity_id], icon: getIconForDomain(domain) }, domain);
   }
 
   AddEntityInfo(entity_id: string, cfg: IEntityConfigEntry) {
     if (this.entities[entity_id]) {
-      Object.assign(this.entities[entity_id], omit({ ...cfg }, "actions"));
-      if (has(cfg, "actions")) {
+      Object.assign(this.entities[entity_id], omit({ ...cfg }, 'actions'));
+      if (has(cfg, 'actions')) {
         each(cfg.actions, action => {
-          let match = find(this.entities[entity_id]["actions"], e => {
-            return (
-              CreateSlug(pick(e, ["service", "service_data"])) ==
-              CreateSlug(pick(action, ["service", "service_data"]))
-            );
-          });
+          let match = find(this.entities[entity_id]['actions'], e => { return CreateSlug(pick(e, ['service', 'service_data'])) == CreateSlug(pick(action, ['service', 'service_data'])) });
           if (match) return;
-          let actions = [...this.entities[entity_id]["actions"]];
+          let actions = [... this.entities[entity_id]['actions']];
           actions.push(action);
-          this.entities[entity_id]["actions"] = actions;
+          this.entities[entity_id]['actions'] = actions;
         });
       }
-    } else {
+    }
+    else {
       let entry = Object.assign({ ...cfg }, { id: entity_id });
       defaults(entry, { actions: [] });
       this.entities[entity_id] = entry;
@@ -149,30 +104,26 @@ export class Config {
 
     if (this.discoverExisting) {
       let res = filter(entityList, e => IsSchedulerEntity(e.entity_id));
-      res = map(res, e => {
-        return e.attributes["actions"];
-      });
+      res = map(res, e => { return e.attributes['actions'] });
       res = flatten(res);
       each(res, item => {
-        let config = { ...item };
-        if (!getDomainFromEntityId(config["entity"])) {
-          config["entity"] =
-            getDomainFromEntityId(config["service"]) + "." + config["entity"];
-          config["service"] = config["service"].split(".").pop();
+        let config = { ...item }
+        if (!getDomainFromEntityId(config['entity'])) {
+          config['entity'] = getDomainFromEntityId(config['service']) + "." + config['entity'];
+          config['service'] = config['service'].split('.').pop();
         }
-        let service_data = omit(config, ["entity", "service"]);
+        let service_data = omit(config, ['entity', 'service']);
         if (service_data) {
-          this.AddEntityInfo(config["entity"], {
-            actions: [
-              { service: config["service"], service_data: service_data }
-            ]
-          });
-        } else {
-          this.AddEntityInfo(config["entity"], {
-            actions: [pick(config, "service")]
+          this.AddEntityInfo(config['entity'], {
+            actions: [{ service: config['service'], service_data: service_data }]
           });
         }
-      });
+        else {
+          this.AddEntityInfo(config['entity'], {
+            actions: [pick(config, 'service')]
+          });
+        }
+      })
     }
 
     each(this.entities, (cfg, entity_id) => {
@@ -185,38 +136,30 @@ export class Config {
       });
 
       Object.assign(cfg, {
-        actions: map(cfg["actions"], action => {
+        actions: map(cfg['actions'], action => {
           let config = { ...action };
           defaults(config, {
-            name: getNameForService(action["service"]),
-            icon: getIconForAction(action["service"])
+            name: getNameForService(action['service']),
+            icon: getIconForAction(action['service'])
           });
-          Object.assign(config, {
-            id: CreateSlug(pick(action, ["service", "service_data"]))
-          });
+          Object.assign(config, { id: CreateSlug(pick(action, ['service', 'service_data'])) });
           return config;
         })
       });
     });
 
-    if (entityList["sun.sun"]) {
-      this.next_sunrise = new Date(
-        entityList["sun.sun"].attributes.next_rising
-      );
-      this.next_sunset = new Date(
-        entityList["sun.sun"].attributes.next_setting
-      );
+    if (entityList['sun.sun']) {
+      this.next_sunrise = new Date(entityList['sun.sun'].attributes.next_rising);
+      this.next_sunset = new Date(entityList['sun.sun'].attributes.next_setting);
     }
   }
 
   GetGroups(): IDictionary<IButtonEntry> {
     let output = mapValues(this.groups, el => {
-      return pick(el, ["name", "icon"]) as IButtonEntry;
+      return pick(el, ['name', 'icon']) as IButtonEntry
     });
-    each(output, (item, key) => {
-      Object.assign(item, { key: key });
-    });
-    output = sortBy(output, "name");
+    each(output, (item, key) => { Object.assign(item, { key: key }) });
+    output = sortBy(output, 'name');
     return output;
   }
 
@@ -227,24 +170,17 @@ export class Config {
       let groupCfg = this.groups[group_id];
       entities = pickBy(this.entities, (_entityCfg, entity_id) => {
         let domain = getDomainFromEntityId(entity_id);
-        if (groupCfg["domains"] && groupCfg["domains"].includes(domain))
-          return true;
-        else if (
-          groupCfg["entities"] &&
-          groupCfg["entities"].includes(entity_id)
-        )
-          return true;
+        if (groupCfg['domains'] && groupCfg['domains'].includes(domain)) return true;
+        else if (groupCfg['entities'] && groupCfg['entities'].includes(entity_id)) return true;
         else return false;
       });
     }
 
     let output = mapValues(entities, el => {
-      return pick(el, ["name", "icon"]);
+      return pick(el, ['name', 'icon']);
     });
-    each(output, (item, key) => {
-      Object.assign(item, { key: key });
-    });
-    output = sortBy(output, "name");
+    each(output, (item, key) => { Object.assign(item, { key: key }) });
+    output = sortBy(output, 'name');
     return output;
   }
 
@@ -254,15 +190,13 @@ export class Config {
 
   GetActions(entity_id: string): IDictionary<IButtonEntry> {
     let entityCfg = this.entities[entity_id];
-    let actions = keyBy(entityCfg["actions"], "id");
+    let actions = keyBy(entityCfg['actions'], 'id');
 
     let output = mapValues(actions, el => {
-      return pick(el, ["name", "icon"]) as IButtonEntry;
+      return pick(el, ['name', 'icon']) as IButtonEntry
     });
-    each(output, (item, key) => {
-      Object.assign(item, { key: key });
-    });
-    output = sortBy(output, "name");
+    each(output, (item, key) => { Object.assign(item, { key: key }) });
+    output = sortBy(output, 'name');
     return output;
   }
 
@@ -272,5 +206,7 @@ export class Config {
     let res = find(entityCfg.actions, { id: action_id });
     if (res) return res as IActionConfigEntry;
     else return null;
+
   }
+
 }


### PR DESCRIPTION
This adds a conditional to check if the entitiy has a `friendly_name`, otherwise use its `deviceID`.