### PR TITLE
Making RU translations consistant with the rest of UI

### DIFF
--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -2,9 +2,9 @@
   "scheduler": "Планирование",
   "actions": {
     "add": "добавить",
-    "cancel": "отмена",
+    "cancel": "отменить",
     "next": "далее",
-    "save": "записать",
+    "save": "сохранить",
     "delete": "удалить"
   },
   "instructions": {


### PR DESCRIPTION
Here is how how this card is shown in Russian language:

![](https://user-images.githubusercontent.com/47263/93456914-faac8c00-f8e6-11ea-95d3-33cc9d0a3630.png)

But in the other parts of Home Assistant Interface different words are used:

![](https://user-images.githubusercontent.com/47263/93456905-f8e2c880-f8e6-11ea-989f-1842d71fb357.png)

This PR makes fixes this 

