### PR TITLE
Alias labels

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,0 +1,4 @@
+label-alias:
+  bug: 'bug'
+  feature_request: 'enhancement'
+  question: 'question'


### PR DESCRIPTION
Alias issue label bot labels to correspond with the default GitHub ones.