### PR TITLE
Fix prettier config format

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
-module.exports = {
-    semi: true,
-    trailingComma: 'all',
-    singleQuote: true,
-    printWidth: 120,
-    tabWidth: 2,
-};
+{
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true,
+    "printWidth": 120,
+    "tabWidth": 2
+}


### PR DESCRIPTION
The config file was in the wrong format.

Be careful, once this is merged, eslint will work again and you have a lot of lint error in  your source code.

Use VSCode with auto-format to help you with ;)

And please add EOF newline + remove EOL blank / space (this is pretty standard)