### PR TITLE
Better createElement typing + remove useless async

### DIFF
--- a/src/scheduler-card.ts
+++ b/src/scheduler-card.ts
@@ -39,8 +39,8 @@ console.info(
 
 @customElement('scheduler-card')
 export class SchedulerCard extends LitElement {
-  public static async getConfigElement(): Promise<LovelaceCardEditor> {
-    return document.createElement('scheduler-card-editor') as LovelaceCardEditor;
+  public static getConfigElement(): LovelaceCardEditor {
+    return document.createElement('scheduler-card-editor');
   }
 
   static get styles(): CSSResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,13 @@
 
 
 import { ITime, IDays } from './date-time';
-import { LovelaceCardConfig } from 'custom-card-helpers';
+import { LovelaceCardEditor, LovelaceCardConfig } from 'custom-card-helpers';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "scheduler-card-editor": LovelaceCardEditor;
+  }
+}
 
 export interface IDictionary<TValue> {
   [id: string]: TValue;


### PR DESCRIPTION
You dont need this function to be `async` because `createElement` is not `aync`

I dont know why they make the boilerplate `async`, I will ask around.

Also fix the element return type so you do not have to cast it.