### PR TITLE
Change color of a tag, good for dark mode

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -78,4 +78,10 @@ export const commonStyle = css`
       display: flex;
       align-items: center;
     }
+    a {
+      color: var(--primary-color);
+    }
+    a:visited {
+      color: var(--accent-color);
+    }
   `;


### PR DESCRIPTION
For the schema editor, it looks bad in dark mode. This fixes it.