### PR TITLE
Update RO trans for 1.9 update

### DIFF
--- a/src/localize/languages/ro.json
+++ b/src/localize/languages/ro.json
@@ -1,127 +1,127 @@
 {
   "services": {
     "generic": {
-      "parameter_to_value": "{parameter} to {value}",
-      "action_with_parameter": "{action} with {parameter}"
+      "parameter_to_value": "{parameter} la {value}",
+      "action_with_parameter": "{action} cu {parameter}"
     },
     "climate": {
-      "set_temperature": "set temperature[ to {temperature}]",
-      "set_temperature_hvac_mode_heat": "heat[ to {temperature}]",
-      "set_temperature_hvac_mode_cool": "cool[ to {temperature}]",
-      "set_hvac_mode": "set mode[ to {hvac_mode}]",
-      "set_preset_mode": "set preset[ {preset_mode}]"
+      "set_temperature": "setare temperatură[ la {temperature}]",
+      "set_temperature_hvac_mode_heat": "încălzire[ la {temperature}]",
+      "set_temperature_hvac_mode_cool": "răcire[ la {temperature}]",
+      "set_hvac_mode": "setare mod[ la {hvac_mode}]",
+      "set_preset_mode": "setare preset[ {preset_mode}]"
     },
     "cover": {
-      "close_cover": "close",
-      "open_cover": "open",
-      "set_cover_position": "set position[ to {position}]"
+      "close_cover": "închidere",
+      "open_cover": "deschidere",
+      "set_cover_position": "setare poziție[ la {position}]"
     },
     "fan": {
-      "set_speed": "set speed[ to {speed}]",
-      "set_direction": "set direction[ to {direction}]",
-      "oscillate": "set oscillation[ to {oscillate}]"
+      "set_speed": "setare viteză[ la {speed}]",
+      "set_direction": "setare direcție[ la {direction}]",
+      "oscillate": "setare oscilare[ la {oscillate}]"
     },
     "humidifier": {
-      "set_humidity": "set humidity[ to {humidity}]"
+      "set_humidity": "setare umiditate[ la {humidity}]"
     },
     "input_number": {
-      "set_value": "set value[ to {value}]"
+      "set_value": "setare valoare[ la {value}]"
     },
     "input_select": {
-      "select_option": "select option[ {option}]"
+      "select_option": "selectare opțiune[ {option}]"
     },
     "light": {
-      "turn_on": "turn on[ with {brightness} brightness]"
+      "turn_on": "pornire[ cu luminozitate {brightness}]"
     },
     "media_player": {
-      "select_source": "select source[ {source}]"
+      "select_source": "selectare sursă[ {source}]"
     },
     "script": {
-      "script": "execute"
+      "script": "executare"
     },
     "vacuum": {
-      "start_pause": "start / pause"
+      "start_pause": "start / pauză"
     },
     "water_heater": {
-      "set_away_mode": "set away mode"
+      "set_away_mode": "setare mod plecat de acasă"
     }
   },
   "domains": {
-    "alarm_control_panel": "alarm control panel",
-    "climate": "climate",
-    "cover": "covers",
-    "fan": "fans",
-    "group": "groups",
-    "humidifier": "humifiers",
+    "alarm_control_panel": "panou control alarmă",
+    "climate": "climat",
+    "cover": "jaluzele",
+    "fan": "ventilatoare",
+    "group": "grupuri",
+    "humidifier": "umidificatoare",
     "input_boolean": "input boolean",
-    "input_number": "input number",
+    "input_number": "input număr",
     "input_select": "input select",
-    "light": "lights",
-    "lock": "locks",
-    "media_player": "media players",
-    "scene": "scenes",
-    "script": "scripts",
-    "switch": "switches",
-    "vacuum": "vacuums",
-    "water_heater": "water heaters"
+    "light": "lumini",
+    "lock": "încuietori",
+    "media_player": "media playere",
+    "scene": "scene",
+    "script": "scripturi",
+    "switch": "întrerupătoare",
+    "vacuum": "aspiratoare",
+    "water_heater": "încălzitoare apă"
   },
   "ui": {
     "components": {
       "date": {
         "day_types_short": {
-          "daily": "daily",
-          "workdays": "workdays",
-          "weekend": "weekend"
+          "daily": "zilnic",
+          "workdays": "zile lucratoare",
+          "weekend": "sfârșit de săptămână"
         },
         "day_types_long": {
-          "daily": "every day",
-          "workdays": "on workdays",
-          "weekend": "in the weekend"
+          "daily": "zilnic",
+          "workdays": "în timpul săptămînii",
+          "weekend": "la sfârșit de săptămână"
         },
-        "days": "days",
-        "tomorrow": "tomorrow",
-        "repeated_days": "every {days}",
-        "repeated_days_except": "every day except {excludedDays}",
-        "days_range": "from {startDay} to {endDay}"
+        "days": "zile",
+        "tomorrow": "mâine",
+        "repeated_days": "la fiecare {days} zile",
+        "repeated_days_except": "zilnic cu excepția {excludedDays}",
+        "days_range": "din {startDay} până în {endDay}"
       },
       "time": {
-        "absolute": "at {time}",
-        "interval": "from {startTime} to {endTime}",
-        "midnight": "midnight",
-        "noon": "noon",
-        "at_sun_event": "at {sunEvent}"
+        "absolute": "la {time}",
+        "interval": "de la {startTime} până la {endTime}",
+        "midnight": "miezul nopții",
+        "noon": "amiază",
+        "at_sun_event": "la {sunEvent}"
       }
     },
     "panel": {
       "common": {
-        "title": "Scheduler"
+        "title": "Planificator"
       },
       "overview": {
-        "no_entries": "There are no items to show",
-        "excluded_items": "{number} excluded {if number is 1} item {else} items",
-        "hide_excluded": "hide excluded items",
-        "additional_tasks": "{number} more {if number is 1} task {else} tasks"
+        "no_entries": "Nu există elemente de afișat",
+        "excluded_items": "{if number is 1}un element exclus {else}{number} elemente excluse",
+        "hide_excluded": "ascunde elementele excluse",
+        "additional_tasks": "{if number is 1}o sarcină suplimentară {else}{number} sarcini suplimentare"
       },
       "entity_picker": {
-        "no_groups_defined": "There are no groups defined",
-        "no_group_selected": "Select a group first",
-        "no_entities_for_group": "There are no entities in this group",
-        "no_entity_selected": "Select an entity first",
-        "no_actions_for_entity": "There are no actions for this entity",
-        "make_scheme": "make scheme"
+        "no_groups_defined": "Nu există grupuri definite",
+        "no_group_selected": "Prima dată selectați un grup",
+        "no_entities_for_group": "Nu există entități definite în acest grup",
+        "no_entity_selected": "Prima dată selectați o entitate",
+        "no_actions_for_entity": "Nu există acțiuni pentru această entitate",
+        "make_scheme": "creare schemă"
       },
       "time_picker": {
-        "no_timeslot_selected": "Select a timeslot first"
+        "no_timeslot_selected": "Prima dată selectați un interval orar"
       },
       "conditions": {
-        "equal_to": "is",
-        "unequal_to": "is not",
-        "all": "all",
-        "any": "any",
-        "no_conditions_defined": "There are no conditions defined"
+        "equal_to": "este",
+        "unequal_to": "nu este",
+        "all": "tot",
+        "any": "oricare",
+        "no_conditions_defined": "Nu există condiții definite"
       },
       "options": {
-        "repeat_type": "behaviour after triggering"
+        "repeat_type": "comportament după declanșare"
       }
     }
   }


### PR DESCRIPTION
Please review lines 101 and 103 because I rearranged the if-else order to make sense in RO:
 - "**excluded_items**": "{if number is 1}un element exclus {else}{number} elemente excluse"
 - "**additional_tasks**": "{if number is 1}o sarcină suplimentară {else}{number} sarcini suplimentare"

Will it be ok and generate the expected result?
- "un element exclus" / "3 elemente excluse";
- "o sarcină suplimentară" / "5 sarcini suplimentare"
