### PR TITLE
Allow schedules with single timeslot

### DIFF
--- a/src/components/timeslot-editor.ts
+++ b/src/components/timeslot-editor.ts
@@ -99,7 +99,7 @@ export class TimeslotEditor extends LitElement {
       </mwc-button>
       <mwc-button
         @click=${this._removeSlot}
-        ?disabled=${this.activeSlot === null || this.slots.length <= 2}
+        ?disabled=${this.activeSlot === null || this.slots.length <= 1}
       >
         <ha-icon icon="hass:minus-circle-outline" class="padded-right"></ha-icon>
         ${this.hass.localize('ui.common.delete')}


### PR DESCRIPTION
I'm trying to solve a small quirk I noticed. I have added two schedules for heating: one when I am home, one when I am away. The schedules each have conditions that check my alarm system, the "home" schedule checks "alarm is Armed", the "away" schedule checks "alarm is not Armed" and both have the `track_conditions` checked since the alarm state can be updated at any time of the day.

Now the only way to accomplish this currently is to set up a schedule, since `track_conditions` is only available when a timeslot has a start and stop time, which simple timers don't have. However schedules currently need to have two different timeslots, which is annoying since my "away" schedule just keeps the same temperature all the time. I can't drag the start of the schedule to midnight either, there seems to be a UI enforcement of 30 min length minimum for each timeslot.

My proposal is to allow removing timeslots as long as one still exists, it will simply span the entire day from midnight to midnight. This should allow everything to work properly, when my alarm is set that timeslot will become active, conditions will be re-evaluated and the correct temperature should be set.