### PR TITLE
Force time-picker css to always use LTR direction

### DIFF
--- a/src/components/time-picker.ts
+++ b/src/components/time-picker.ts
@@ -312,6 +312,7 @@ export class TimePicker extends LitElement {
         'hours-down .         minutes-down suffix options';
       grid-gap: 4px 0px;
       align-items: center;
+      direction: ltr;
     }
 
     div.hours-up {


### PR DESCRIPTION
This PR is to fix #608
When selecting RTL (right-to-left) languages such as Hebrew as your interface language, the time picker is displayed as MM:HH instead of HH:MM.
This PR simply forces the time picker to always use LTR in its CSS, even when RTL languages are selected.