### PR TITLE
lock custom-card-helpers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@rollup/plugin-json": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^2.6.0",
     "@typescript-eslint/parser": "^2.6.0",
-    "custom-card-helpers": "^1.7.2",
+    "custom-card-helpers": "1.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-import": "^2.18.2",


### PR DESCRIPTION
right now the version specified in the package.json for `custom-card-helpers` is `^1.7.2` this will bring version `1.9.0` (at the moment of this PR). which is incompatible with the source code. 
This lock the version to a compatible version.