### PR TITLE
add babel cli to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "^3.6.4"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "eslint": "^6.8.0",
     "prettier": "1.19.1",
     "rollup-plugin-visualizer": "^5.5.2"


### PR DESCRIPTION
right now the babel script assumes the developer installed babel-cli globally.
adding babel-cli to devDependencies to avoid it.