### PR TITLE
Update lit version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-prettier": "^3.1.1",
     "fecha": "^4.2.1",
     "home-assistant-js-websocket": "^5.7.0",
-    "lit": "^2.0.0-rc.2",
+    "lit": "^2.0.0",
     "rollup": "^1.32.1",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
I noticed that this was using an out-of-date pre-release version of Lit, which will not pick up bug fixes.

We're about to release Lit 3.0, but this is the most conservative change to do for now.