### PR TITLE
Add option to customize the style of the timeslots

### DIFF
--- a/src/config-validation.ts
+++ b/src/config-validation.ts
@@ -103,6 +103,7 @@ export function ValidateConfig(config: any) {
   Optional(config, 'show_header_toggle', 'boolean');
   Optional(config, 'show_add_button', 'boolean');
   Optional(config, 'sort_by', ['string', 'array']);
+  Optional(config, 'timeslot_style', 'string');
 
   Optional(config, 'include', 'array');
   RequiredArrayType(config, 'include', 'string');

--- a/src/editor/scheduler-editor-time.ts
+++ b/src/editor/scheduler-editor-time.ts
@@ -32,7 +32,7 @@ import '../components/variable-picker';
 @customElement('scheduler-editor-time')
 export class SchedulerEditorTime extends LitElement {
   @property()
-  hass?: HomeAssistant;
+  hass!: HomeAssistant;
 
   @property()
   config?: CardConfig;
@@ -117,6 +117,7 @@ export class SchedulerEditorTime extends LitElement {
 
               <timeslot-editor
                 .hass=${this.hass}
+                .config=${this.config}
                 .actions=${this.actions}
                 .slots=${this.schedule.timeslots}
                 stepSize=${this.config.time_step || DefaultTimeStep}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -221,6 +221,10 @@
             "heading": "Included entities",
             "description": "Select the entities that you want to control using the scheduler. You can click on a group to open it. Note that some entities (such as sensors) can only be used for conditions, not for actions.",
             "included_number": "{number}/{total} selected"
+          },
+          "timeslot_style": {
+            "heading": "Timeslot style function",
+            "description": "Javascript function that can be used to customize timeslot styles."
           }
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,7 @@ export interface CardConfig extends LovelaceCardConfig {
   tags?: string[] | string;
   exclude_tags?: string[] | string;
   sort_by: string[] | string;
+  timeslot_style?: string;
 }
 
 /* interface */


### PR DESCRIPTION
Adds a new ``timeslot_style`` option which can be used to customize the style of the timeslots shown in the scheduler card.

For example, this can be used to change the background color based on the service data, such as temperature or preset.

<img width="402" alt="image" src="https://github.com/nielsfaber/scheduler-card/assets/3200395/417101f8-37fa-4b9f-8ac7-819547ac143e">

The ``timeslot_style`` option is a JavaScript function that gets called for each timeslot and returns a style object, which is added to the timeslot.

More details and example usage have been added to the readme file.

#Fixes #758