### PR TITLE
Run prettier and lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,10 @@ module.exports = {
     "@typescript-eslint/camelcase": 0,
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/ban-ts-ignore": "off"
   }
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+## Building
+
+* Install Node.js (latest LTS release).
+  * On Linux, macOS, or Windows WSL, consider using [nvm.sh](https://github.com/nvm-sh/nvm/blob/master/README.md)
+  * On Windows native, see [Nodejs.org](https://nodejs.org/)
+* `git clone https://github.com/nielsfaber/scheduler-card.git`
+* `cd scheduler-card`
+* `npm install --no-package-lock`
+* `npm start`  # To develop interactively
+* `npm run build`  # Run lint, prettier, rollup (update 'dist/scheduler-card.js')
+
+
+## Codebase rewrite
+
+Please note that a major rewrite of the codebase is ongoing as of March 2024. If you are
+planning on submitting a significant contribution, get in touch to request a branch for
+the new version to be published so that you can rebase your work on it.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "Scheduler card for Lovelace",
   "main": "dist/scheduler-card.js",
   "scripts": {
-    "build": "npm run lint && npm run rollup && npm run babel",
+    "build": "npm run lint && npm run format && npm run rollup",
     "rollup": "rollup -c",
-    "babel": "babel dist/scheduler-card.js --out-file dist/scheduler-card.js",
     "lint": "eslint src/**/*.ts --fix",
     "format": "prettier --write '**/*.ts'",
     "start": "rollup -c --watch"
@@ -22,9 +21,6 @@
   },
   "homepage": "https://github.com/nielsfaber/scheduler-card#readme",
   "dependencies": {
-    "@babel/core": "^7.6.4",
-    "@babel/plugin-proposal-class-properties": "^7.5.5",
-    "@babel/plugin-proposal-decorators": "^7.4.0",
     "@formatjs/intl-utils": "^3.8.4",
     "@mdi/js": "^6.4.95",
     "@typescript-eslint/eslint-plugin": "^2.6.0",
@@ -38,7 +34,6 @@
     "home-assistant-js-websocket": "^5.7.0",
     "lit": "^2.0.0",
     "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -49,7 +44,6 @@
     "typescript": "^3.6.4"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
     "eslint": "^6.8.0",
     "prettier": "1.19.1",
     "rollup-plugin-visualizer": "^4.2.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript2';
-import babel from 'rollup-plugin-babel';
 import json from 'rollup-plugin-json';
 import { terser } from 'rollup-plugin-terser';
 import commonjs from 'rollup-plugin-commonjs';
@@ -14,9 +13,6 @@ const plugins = [
   }),
   typescript(),
   json(),
-  babel({
-    exclude: 'node_modules/**',
-  }),
   visualizer(),
   terser(),
 ];

--- a/src/components/timeslot-editor.ts
+++ b/src/components/timeslot-editor.ts
@@ -139,7 +139,12 @@ export class TimeslotEditor extends LitElement {
         if (!!icons) {
           return html`
             <span style="margin-left: auto; margin-right: auto">
-                ${icons.map((icon) => html`<ha-icon icon="${icon}"></ha-icon>`)}
+              ${icons.map(
+                icon =>
+                  html`
+                    <ha-icon icon="${icon}"></ha-icon>
+                  `
+              )}
             </span>
           `;
         }
@@ -170,8 +175,7 @@ export class TimeslotEditor extends LitElement {
                 </div>
               `
             : ''}
-          ${i > 0 ? this.renderTooltip(i) : ''}
-          ${content}
+          ${i > 0 ? this.renderTooltip(i) : ''} ${content}
         </div>
       `;
     });
@@ -258,29 +262,30 @@ export class TimeslotEditor extends LitElement {
     if (!entry.actions) return;
 
     return unique(
-      entry.actions.map(action => {
-        const actionConfig = this.actions.find(e => compareActions(e, action, true));
-        if (!actionConfig) return [];
+      entry.actions
+        .map(action => {
+          const actionConfig = this.actions.find(e => compareActions(e, action, true));
+          if (!actionConfig) return [];
 
-        if (
-          actionConfig.variables &&
-          Object.keys(actionConfig.variables).some(field => action.service_data && field in action.service_data)
-        ) {
-          return Object.entries(actionConfig.variables)
-            .filter(([field]) => action.service_data && field in action.service_data)
-            .map(([field, variable]) => {
-              const value = action.service_data![field];
-              if (variable.type == EVariableType.List) {
-                variable = variable as ListVariable;
-                const listItem = variable.options.find(e => e.value == value);
-                return listItem?.icon;
-              } else return undefined;
-            });
-        }
-        return [actionConfig.icon];
-      })
-      .reduce((prev, icons) => [...prev, ...icons], [])
-      .filter((icon) => !!icon)
+          if (
+            actionConfig.variables &&
+            Object.keys(actionConfig.variables).some(field => action.service_data && field in action.service_data)
+          ) {
+            return Object.entries(actionConfig.variables)
+              .filter(([field]) => action.service_data && field in action.service_data)
+              .map(([field, variable]) => {
+                const value = action.service_data![field];
+                if (variable.type == EVariableType.List) {
+                  variable = variable as ListVariable;
+                  const listItem = variable.options.find(e => e.value == value);
+                  return listItem?.icon;
+                } else return undefined;
+              });
+          }
+          return [actionConfig.icon];
+        })
+        .reduce((prev, icons) => [...prev, ...icons], [])
+        .filter(icon => !!icon)
     );
   }
 

--- a/src/standard-configuration/variables.ts
+++ b/src/standard-configuration/variables.ts
@@ -41,14 +41,14 @@ export const parseVariable = (
   const res =
     'template' in config && isDefined(config.template)
       ? { ...omit(config, 'template'), ...config.template(stateObj, hass) }
-      : <ListVariableConfig | LevelVariableConfig | TextVariableConfig>{ ...config };
+      : ({ ...config } as ListVariableConfig | LevelVariableConfig | TextVariableConfig);
 
   if ('options' in res) {
     return parseListVariable(res, stateObj);
   } else if ('min' in res && 'max' in res) {
     return parseLevelVariable(res, stateObj);
   } else {
-    return <TextVariableConfig>res;
+    return res as TextVariableConfig;
   }
 };
 


### PR DESCRIPTION
While working on another PR (not pushed yet), I found that `npm run format` and `npm run lint` would modify not only the code I was writing, but also pre-existing files in the main branch. In order to avoid unnecessary noise in my other PR, I thought I would sort the pre-existing issues first, through this PR.

While at it, @nielsfaber here’s a question: Are contributors supposed to run `npm run build` that calls `babel`? I have found that file [dist/scheduler-card.js](https://github.com/nielsfaber/scheduler-card/blob/v3.2.12/dist/scheduler-card.js) in release v3.2.12 (current latest), as well as the same file in the main branch, looks more like `babel` or `npm run build` were _not_ executed. It looks more like it was created with just `npm run rollup`. Having said that, I was not able to reproduce the exact file with either command. Here’s what I get:

```
$ nvm install --lts
$ nvm use --lts
$ node --version
v20.11.1
$ npm --version
10.2.4
$ cd scheduler-card
$ git checkout main
$ rm -rf package-lock.json node_modules
$ npm install
$ npm run rollup
$ ls -l dist/scheduler-card.js
# The original file was about 6kB smaller
-rw-r--r--  1 paulo  staff  318436 24 Mar 22:33 dist/scheduler-card.js

$ npm run build
# eslint fails. I fix the eslint issues as per changes in this PR.

$ npm run build
> scheduler-card@1.0.0 build
> npm run lint && npm run rollup && npm run babel
> eslint src/**/*.ts --fix
> rollup -c
src/scheduler-card.ts → dist...
> babel dist/scheduler-card.js --out-file dist/scheduler-card.js

SyntaxError: dist/scheduler-card.js: Unexpected token (34:78)
  32 |      * Copyright 2017 Google LLC
  33 |      * SPDX-License-Identifier: BSD-3-Clause
> 34 |      */,le=(e,t)=>"method"===t.kind&&t.descriptor&&!("value"in t.descriptor)?{...t,finisher(i){i.createProperty(t.key,e)}}:{kind:"field",key:Symbol(),placement:"own",descriptor:{},originalKey:t.key,initializer(){"function"==typeof t.initializer&&(this[t.key]=t.initializer.call(this))},finisher(i){i.createProperty(t.key,e)}};function de(e){return(t,i)=>void 0!==i?((e,t,i)=>{t.constructor.createProperty(i,e)})(e,t,i):le(e,t)
     |                                                                               ^

# I found that the error above goes away if the babel CLI in ‘devDependencies’
# is upgraded from `"babel-cli": "^6.26.0"` to `"@babel/cli": "^7.24.1"`, however 
# `dist/scheduler-card.js` then increases in size by more than 100kB!
$ rm -rf package-lock.json node_modules
$ npm install
$ npm run build
$ ls -l dist/scheduler-card.js
-rw-r--r--  1 paulo  staff  422383 24 Mar 22:41 dist/scheduler-card.js
```

What is the correct procedure to generate `dist/scheduler-card.js`?
