### PR TITLE
Add the time domain (time entities) to the list of standard configuration actions

### DIFF
--- a/src/components/timeslot-editor.ts
+++ b/src/components/timeslot-editor.ts
@@ -3,10 +3,11 @@ import { customElement, property, eventOptions } from 'lit/decorators';
 import { mdiUnfoldMoreVertical } from '@mdi/js';
 import { HomeAssistant } from 'custom-card-helpers';
 
-import { Timeslot, Action, EVariableType, LevelVariable, ListVariable } from '../types';
+import { Timeslot, Action, EVariableType, LevelVariable, ListVariable, TimeVariable } from '../types';
 import { stringToTime, timeToString, roundTime, parseRelativeTime } from '../data/date-time/time';
 import { compareActions } from '../data/actions/compare_actions';
 import { levelVariableDisplay } from '../data/variables/level_variable';
+import { timeVariableDisplay } from '../data/variables/time_variable';
 import { unique, PrettyPrintName, getLocale } from '../helpers';
 import { localize } from '../localize/localize';
 import { stringToDate } from '../data/date-time/string_to_date';
@@ -246,6 +247,9 @@ export class TimeslotEditor extends LitElement {
                 variable = variable as ListVariable;
                 const listItem = variable.options.find(e => e.value == value);
                 return PrettyPrintName(listItem && listItem.name ? listItem.name : String(value));
+              } else if (variable.type == EVariableType.Time) {
+                variable = variable as TimeVariable;
+                return timeVariableDisplay(value, variable);
               } else return '';
             })
             .join(', ');

--- a/src/components/variable-picker.ts
+++ b/src/components/variable-picker.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
-import { Variable, LevelVariable, EVariableType, ListVariable, TextVariable } from '../types';
+import { HomeAssistant } from 'custom-card-helpers';
+import { Variable, LevelVariable, EVariableType, ListVariable, TextVariable, TimeVariable } from '../types';
 
 import './variable-slider';
 import './button-group';
@@ -8,6 +9,9 @@ import { fireEvent } from 'custom-card-helpers';
 
 @customElement('scheduler-variable-picker')
 export class SchedulerVariablePicker extends LitElement {
+  @property()
+  hass?: HomeAssistant;
+
   @property()
   variable?: Variable | null;
 
@@ -28,6 +32,7 @@ export class SchedulerVariablePicker extends LitElement {
     else if (this.variable.type == EVariableType.Level) return this.renderLevelVariable();
     else if (this.variable.type == EVariableType.List) return this.renderListVariable();
     else if (this.variable.type == EVariableType.Text) return this.renderTextVariable();
+    else if (this.variable.type == EVariableType.Time) return this.renderTimeVariable();
     else return html``;
   }
 
@@ -83,9 +88,33 @@ export class SchedulerVariablePicker extends LitElement {
     `;
   }
 
+  renderTimeVariable() {
+    if (!this.hass || !this.variable) {
+      console.warn(`${this.renderTimeVariable.name}() not rendering: undefined references`);
+      return html``;
+    }
+    const variable = this.variable as TimeVariable;
+    const value = this.value;
+
+    return html`
+      <ha-time-input
+        .enableSecond=${variable.enable_seconds}
+        .value=${value}
+        .locale=${this.hass.locale}
+        @value-changed=${this.listVariableUpdated}
+      ></ha-time-input>
+      <div class="key">${variable.enable_seconds ? 'Hours:Minutes:Seconds' : 'Hours:Minutes'}</div>
+    `;
+  }
+
   static styles = css`
     ha-textfield {
       width: 100%;
+    }
+    div.key {
+      color: var(--mdc-text-field-label-ink-color, rgba(0, 0, 0, 0.6));
+      font-style: italic;
+      font-size: 0.75rem;
     }
   `;
 }

--- a/src/data/actions/assign_action.ts
+++ b/src/data/actions/assign_action.ts
@@ -1,4 +1,12 @@
-import { Action, EVariableType, LevelVariable, ListVariable, ServiceCall, TextVariable } from '../../types';
+import {
+  Action,
+  EVariableType,
+  LevelVariable,
+  ListVariable,
+  ServiceCall,
+  TextVariable,
+  TimeVariable,
+} from '../../types';
 import { omit } from '../../helpers';
 
 export const assignAction = (entity_id: string, action: Action) => {
@@ -30,6 +38,15 @@ export const assignAction = (entity_id: string, action: Action) => {
         service_data: {
           ...output.service_data,
           [key]: config.options.length ? config.options[0].value : undefined,
+        },
+      };
+    } else if (config.type == EVariableType.Time) {
+      config = config as TimeVariable;
+      output = {
+        ...output,
+        service_data: {
+          ...output.service_data,
+          [key]: config.enable_seconds ? '00:00:00' : '00:00',
         },
       };
     } else if (config.type == EVariableType.Text) {

--- a/src/data/actions/compare_actions.ts
+++ b/src/data/actions/compare_actions.ts
@@ -48,6 +48,7 @@ export function compareActions(actionA: Action, actionB: Action, allowVars = fal
     if (variable.type === EVariableType.List) {
       return (variable as ListVariable).options.some(e => e.value === value);
     } else if (variable.type === EVariableType.Level) return !isNaN(value);
+    else if (variable.type == EVariableType.Time) return true;
     else if (variable.type == EVariableType.Text) return true;
 
     return false;

--- a/src/data/actions/compute_action_display.ts
+++ b/src/data/actions/compute_action_display.ts
@@ -1,9 +1,10 @@
 import { computeEntity } from 'custom-card-helpers';
-import { Action, EVariableType, LevelVariable, ListVariable, TextVariable } from '../../types';
+import { Action, EVariableType, LevelVariable, ListVariable, TextVariable, TimeVariable } from '../../types';
 import { levelVariableDisplay } from '../variables/level_variable';
 import { PrettyPrintName } from '../../helpers';
 import { listVariableDisplay } from '../variables/list_variable';
 import { textVariableDisplay } from '../variables/text_variable';
+import { timeVariableDisplay } from '../variables/time_variable';
 
 const wildcardPattern = /\{([^\}]+)\}/;
 const parameterPattern = /\[([^\]]+)\]/;
@@ -26,6 +27,8 @@ export function computeActionDisplay(action: Action) {
         replacement = levelVariableDisplay(action.service_data![field], action.variables![field] as LevelVariable);
       else if (action.variables![field].type == EVariableType.List)
         replacement = listVariableDisplay(action.service_data![field], action.variables![field] as ListVariable);
+      else if (action.variables![field].type == EVariableType.Time)
+        replacement = timeVariableDisplay(action.service_data![field], action.variables![field] as TimeVariable);
       else replacement = textVariableDisplay(action.service_data![field], action.variables![field] as TextVariable);
     } else {
       replacement = action.service_data![field];

--- a/src/data/actions/migrate_action_config.ts
+++ b/src/data/actions/migrate_action_config.ts
@@ -46,6 +46,7 @@ export const migrateActionConfig = (
             );
           else return null;
 
+        case EVariableType.Time:
         case EVariableType.Text:
           //keep the selected text variable
           return output.map(e =>

--- a/src/data/variables/compute_merged_variable.ts
+++ b/src/data/variables/compute_merged_variable.ts
@@ -1,13 +1,14 @@
-import { LevelVariable, ListVariable, TextVariable, EVariableType } from '../../types';
+import { LevelVariable, ListVariable, TextVariable, TimeVariable, EVariableType } from '../../types';
 import { levelVariable } from './level_variable';
 import { listVariable } from './list_variable';
 import { textVariable } from './text_variable';
+import { timeVariable } from './time_variable';
 import { isDefined, unique } from '../../helpers';
 import { computeVariables } from './compute_variables';
 
 export function computeMergedVariable(
   ...variables: Partial<LevelVariable | ListVariable | TextVariable>[]
-): LevelVariable | ListVariable | TextVariable | undefined {
+): LevelVariable | ListVariable | TextVariable | TimeVariable | undefined {
   const types = unique(variables.map(e => e.type).filter(isDefined));
   if (!types.length) {
     variables = Object.values(computeVariables(Object.assign({}, ...variables))!);
@@ -18,6 +19,8 @@ export function computeMergedVariable(
 
   if (types[0] == EVariableType.Level) {
     return levelVariable(...(variables as LevelVariable[]));
+  } else if (types[0] == EVariableType.Time) {
+    return timeVariable(...(variables as TimeVariable[]));
   } else if (types[0] == EVariableType.List) {
     return listVariable(...(variables as ListVariable[]));
   } else return textVariable(...(variables as TextVariable[]));

--- a/src/data/variables/compute_variables.ts
+++ b/src/data/variables/compute_variables.ts
@@ -1,7 +1,8 @@
-import { LevelVariable, ListVariable, TextVariable, Dictionary, VariableDictionary } from '../../types';
+import { LevelVariable, ListVariable, TextVariable, TimeVariable, Dictionary, VariableDictionary } from '../../types';
 import { listVariable } from './list_variable';
 import { levelVariable } from './level_variable';
 import { textVariable } from './text_variable';
+import { timeVariable } from './time_variable';
 
 export function computeVariables(
   variables?: Dictionary<Partial<LevelVariable | ListVariable | TextVariable>>
@@ -14,6 +15,8 @@ export function computeVariables(
         return [field, listVariable(variable as ListVariable)];
       } else if ('min' in variable || 'max' in variable) {
         return [field, levelVariable(variable as LevelVariable)];
+      } else if ('enable_seconds' in variable) {
+        return [field, timeVariable(variable as TimeVariable)];
       } else {
         return [field, textVariable(variable as TextVariable)];
       }

--- a/src/data/variables/time_variable.ts
+++ b/src/data/variables/time_variable.ts
@@ -1,0 +1,19 @@
+import { isDefined } from '../../helpers';
+import { EVariableType, TimeVariable } from '../../types';
+
+export function timeVariable(...config: Partial<TimeVariable>[]) {
+  //factory function to create TimeVariable from configuration
+
+  const name = config.map(e => e.name).filter(isDefined);
+
+  const variable: TimeVariable = {
+    type: EVariableType.Time,
+    name: name.length ? name.reduce((_acc, val) => val) : undefined,
+    enable_seconds: config.some(e => e.enable_seconds),
+  };
+  return variable;
+}
+
+export function timeVariableDisplay(value: any, _variable: TimeVariable): string {
+  return String(value);
+}

--- a/src/editor/scheduler-editor-options.ts
+++ b/src/editor/scheduler-editor-options.ts
@@ -465,6 +465,7 @@ export class SchedulerEditorOptions extends LitElement {
 
         <div class="header">${this.hass.localize('ui.panel.config.automation.editor.conditions.type.state.label')}</div>
         <scheduler-variable-picker
+          .hass=${this.hass}
           .variable=${states}
           .value=${this.conditionValue}
           @value-changed=${(ev: CustomEvent) => (this.conditionValue = ev.detail.value)}

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -51,6 +51,9 @@
     "script": {
       "script": "execute"
     },
+    "time": {
+      "set_value": "set value[ to {time}]"
+    },
     "vacuum": {
       "start_pause": "start / pause"
     },
@@ -76,6 +79,7 @@
     "media_player": "media players",
     "notify": "notification",
     "switch": "switches",
+    "time": "time",
     "vacuum": "vacuums",
     "water_heater": "water heaters"
   },

--- a/src/standard-configuration/action_icons.ts
+++ b/src/standard-configuration/action_icons.ts
@@ -123,6 +123,9 @@ const actionIcons: IconList = {
     turn_on: 'mdi:flash',
     turn_off: 'mdi:flash-off',
   },
+  time: {
+    set_value: 'mdi:clock-outline',
+  },
   vacuum: {
     turn_on: 'mdi:power',
     start: 'mdi:play-circle-outline',

--- a/src/standard-configuration/action_name.ts
+++ b/src/standard-configuration/action_name.ts
@@ -105,6 +105,9 @@ const actionNamesList: Record<string, Record<string, string | actionNameTemplate
     turn_on: 'ui.card.vacuum.actions.turn_on',
     turn_off: 'ui.card.vacuum.actions.turn_off',
   },
+  time: {
+    set_value: 'services.time.set_value',
+  },
   vacuum: {
     turn_on: 'ui.card.vacuum.actions.turn_on',
     start: 'ui.card.vacuum.start_cleaning',

--- a/src/standard-configuration/actions.ts
+++ b/src/standard-configuration/actions.ts
@@ -396,6 +396,15 @@ export const actionList: Record<string, Record<string, ActionItem>> = {
     turn_on: {},
     turn_off: {},
   },
+  time: {
+    set_value: {
+      variables: {
+        time: {
+          enable_seconds: true,
+        },
+      },
+    },
+  },
   vacuum: {
     turn_on: { supported_feature: 1 },
     start: {

--- a/src/standard-configuration/standardActions.ts
+++ b/src/standard-configuration/standardActions.ts
@@ -8,6 +8,7 @@ import { HassEntity } from 'home-assistant-js-websocket';
 import { levelVariable } from '../data/variables/level_variable';
 import { listVariable } from '../data/variables/list_variable';
 import { textVariable } from '../data/variables/text_variable';
+import { timeVariable } from '../data/variables/time_variable';
 import { actionName } from './action_name';
 import { actionIcon } from './action_icons';
 import { getVariableName } from './variable_name';
@@ -124,6 +125,8 @@ const parseActionVariable = (
     return listVariable(config);
   } else if ('min' in config && isDefined(config.min) && 'max' in config && isDefined(config.max)) {
     return levelVariable(config);
+  } else if ('enable_seconds' in config && isDefined(config.enable_seconds)) {
+    return timeVariable(config);
   } else {
     return textVariable(config);
   }

--- a/src/standard-configuration/standardIcon.ts
+++ b/src/standard-configuration/standardIcon.ts
@@ -75,6 +75,7 @@ export const domainIcons: Record<string, string> = {
   sensor: 'mdi:eye',
   sun: 'mdi:white-balance-sunny',
   switch: 'mdi:flash',
+  time: 'mdi:clock',
   timer: 'mdi:timer',
   vacuum: 'mdi:robot-vacuum',
   water_heater: 'mdi:water-boiler',

--- a/src/standard-configuration/standardStates.ts
+++ b/src/standard-configuration/standardStates.ts
@@ -4,6 +4,7 @@ import { DefaultActionIcon } from '../const';
 import { levelVariable } from '../data/variables/level_variable';
 import { listVariable } from '../data/variables/list_variable';
 import { textVariable } from '../data/variables/text_variable';
+import { timeVariable } from '../data/variables/time_variable';
 import { getLocale, isDefined } from '../helpers';
 import { localize } from '../localize/localize';
 import { Variable } from '../types';
@@ -43,6 +44,8 @@ export function standardStates(entity_id: string, hass: HomeAssistant): Variable
     return listVariable(stateConfig);
   } else if ('min' in stateConfig && isDefined(stateConfig.min) && 'max' in stateConfig && isDefined(stateConfig.max)) {
     return levelVariable(stateConfig);
+  } else if ('enable_seconds' in stateConfig && isDefined(stateConfig.enable_seconds)) {
+    return timeVariable(stateConfig);
   } else {
     return textVariable(stateConfig);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export enum EVariableType {
   Level = 'LEVEL',
   List = 'LIST',
   Text = 'TEXT',
+  Time = 'TIME',
 }
 
 export interface Variable {
@@ -163,7 +164,11 @@ export interface TextVariable extends Variable {
   multiline: boolean;
 }
 
-export type VariableDictionary = Dictionary<LevelVariable | ListVariable | TextVariable>;
+export interface TimeVariable extends Variable {
+  enable_seconds: boolean;
+}
+
+export type VariableDictionary = Dictionary<LevelVariable | ListVariable | TextVariable | TimeVariable>;
 
 /* entries */
 


### PR DESCRIPTION
This PR addresses issue #807. Please check that issue’s description for background information (use cases, justification).

**Screenshots of what this PR achieves**

***Scheduler Card Configuration — Included Entities***
Before this PR, time entities were not listed — there wasn’t a ‘time’ row in the screenshot below. After this PR, the ‘time’ row is listed, allowing time entities to be selected.
<img width="70%" alt="Scheduler Card Configuration - Entities - Time" src="https://github.com/nielsfaber/scheduler-card/assets/15091591/66af1e01-ec8c-4676-9c60-48735d42e17c" />

***New Schedule - Entity Editor - Time Entity***
<img width="70%" alt="New Schedule - Entity Editor" src="https://github.com/nielsfaber/scheduler-card/assets/15091591/8b3b699f-9041-42fb-a160-ae31ae93174c" />

***New Schedule - Time Editor - Time Entity - Set Value***
<img width="70%" alt="New Schedule - Time Editor" src="https://github.com/nielsfaber/scheduler-card/assets/15091591/9e9364bc-7808-49fb-95cc-3a74e7b8c524" />

***New Schedule - Time Editor - Time Entity - Make Scheme***
<img width="70%" alt="New Schedule - Time Editor - Scheme" src="https://github.com/nielsfaber/scheduler-card/assets/15091591/a90bc40a-4908-4ee9-aa6e-0b89ee0a770a" />

***Scheduler Card - Configured Entities - Time Entity***
<img width="70%" alt="Scheduler Card - Configured Entities" src="https://github.com/nielsfaber/scheduler-card/assets/15091591/0aef89c1-8821-4c26-aa8b-6858d2da89c0" />