### PR TITLE
Pre select entity if there is only one

### DIFF
--- a/src/components/scheduler-entity-picker.ts
+++ b/src/components/scheduler-entity-picker.ts
@@ -32,7 +32,29 @@ export class SchedulerEntityPicker extends LitElement {
   @state() scheduleEntities: string[] = [];
 
   protected async firstUpdated() {
-    this.scheduleEntities = Object.entries(await fetchItems(this.hass!)).map(([, val]) => val.entity_id);
+    this.scheduleEntities = Object.entries(await fetchItems(this.hass!)).map(
+      ([, val]) => val.entity_id
+    );
+    this._autoSelectIfSingleEntity();
+  }
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+
+    // Relevant for type change in conditions
+    if (changedProps.has("domain")) { 
+      this._autoSelectIfSingleEntity();
+    }
+  }
+
+  private _autoSelectIfSingleEntity() {
+    if (this.value && this.value.length > 0) return;
+
+    const items = this._filteredItems();
+    if (items.length === 1) {
+      this.value = [items[0].id];
+      fireEvent(this, "value-changed", { value: this.value });
+    }
   }
 
   private _valueRenderer: PickerValueRenderer = (value) => {


### PR DESCRIPTION
This change ensures that the entity is automatically preselected in two scenarios:
* When adding a new schedule item
* When defining conditions

The preselection occurs when either:
* There is only one entity available overall, or
* only one entity remains within the given domain.