### PR TITLE
Change entity chip delete color

### DIFF
--- a/src/components/scheduler-chip.ts
+++ b/src/components/scheduler-chip.ts
@@ -213,7 +213,7 @@ export class SchedulerChip extends LitElement {
         justify-content: center;
         --mdc-icon-size: 16px;
         margin: 0px 3px 0px -8px;
-        color: var(--icon-color, rgba(0, 0, 0, 0.54));
+        color: var(--secondary-text-color);
         cursor: pointer;
       }
       .trailing-icon:before {


### PR DESCRIPTION
This ensures that the color of the x on the entity chip is light if the dark theme is used.
Currently, it is black on dark background.