### PR TITLE
fix: adjust z-index for scheduler chip styling

### DIFF
--- a/src/components/scheduler-chip.ts
+++ b/src/components/scheduler-chip.ts
@@ -146,7 +146,7 @@ export class SchedulerChip extends LitElement {
         height: var(--chip-height, 32px);
         background: none;
         user-select: none;
-        z-index: 1;
+        z-index: -1;
         align-items: center;
         justify-content: center;
       }


### PR DESCRIPTION
fixed this: <img width="419" height="87" alt="grafik" src="https://github.com/user-attachments/assets/ea112282-1a07-4e76-a7b6-448aa0fca8df" />