### PR TITLE
fix: adjust z-index for scheduler chip styling

### DIFF
--- a/src/components/scheduler-chip.ts
+++ b/src/components/scheduler-chip.ts
@@ -146,7 +146,7 @@ export class SchedulerChip extends LitElement {
         height: var(--chip-height, 32px);
         background: none;
         user-select: none;
-        z-index: 1;
+        z-index: 0;
         align-items: center;
         justify-content: center;
       }


### PR DESCRIPTION
fixed this: 
<img width="446" height="120" alt="grafik" src="https://github.com/user-attachments/assets/72d74f68-13b5-43bd-a561-6ebf294a6137" />
