### PR TITLE
Fix transposed on/off descriptions for water_heater

### DIFF
--- a/src/data/actions/supported_actions.ts
+++ b/src/data/actions/supported_actions.ts
@@ -437,12 +437,12 @@ export const supportedActions: Record<string, Record<string, ActionConfig>> = {
       }
     },
     turn_off: {
-      translation_key: 'services.generic.turn_on',
+      translation_key: 'services.generic.turn_off',
       target: {},
       supported_features: 8
     },
     turn_on: {
-      translation_key: 'services.generic.turn_off',
+      translation_key: 'services.generic.turn_on',
       target: {},
       supported_features: 8
     },


### PR DESCRIPTION
**Issue**
When working with a schedule, the 'turn on' and 'turn off' actions for water heaters had the opposite effect (e.g. 'turn off' actually turns on the water heater).

**Cause**
Minor cosmetic issue - seems the translation keys for these actions were accidentally transposed. 

**Fix**
Swap the translation keys for ```water_heater``` in  ```supported_actions.ts``` to be the correct way around. 

**Testing**
Rebuilt and tested in HA locally. Actions are correctly named / have the correct icon and work as expected. 