### PR TITLE
Allow conditions on individual actions instead of the whole schedule

### DIFF
--- a/src/components/scheduler-conditions-editor.ts
+++ b/src/components/scheduler-conditions-editor.ts
@@ -1,0 +1,393 @@
+import { LitElement, html, css, CSSResultGroup } from 'lit';
+import { property, customElement, state } from 'lit/decorators.js';
+import { mdiCog, mdiDotsVertical, mdiPencil } from '@mdi/js';
+import { CardConfig, Condition, ConditionConfig, TConditionLogicType, TConditionMatchType } from '../types';
+import { DialogSelectConditionParams } from '../dialogs/dialog-select-condition';
+import { computeStatesForEntity } from '../data/compute_states_for_entity';
+import { computeEntityIcon } from '../data/format/compute_entity_icon';
+import { computeEntityDisplay } from '../data/format/compute_entity_display';
+import { computeDomain } from '../lib/entity';
+import { validateSelectorValue } from '../data/selectors/validate_selector_value';
+import { localize } from '../localize/localize';
+import { HomeAssistant } from '../lib/types';
+import { fireEvent } from '../lib/fire_event';
+import { capitalizeFirstLetter } from '../lib/capitalize_first_letter';
+import { asArray } from '../lib/as_array';
+import { hassLocalize } from '../localize/hassLocalize';
+import { formatSelectorDisplay } from '../data/selectors/format_selector_display';
+import { isDefined } from '../lib/is_defined';
+
+import './scheduler-collapsible-section';
+import './scheduler-settings-row';
+import './scheduler-combo-selector';
+import '../dialogs/dialog-select-condition';
+
+const DEFAULT_CONDITIONS: ConditionConfig = {
+  type: TConditionLogicType.Or,
+  items: [],
+  track_changes: false,
+};
+
+@customElement('scheduler-conditions-editor')
+export class SchedulerConditionsEditor extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  @property({ attribute: false }) public config!: CardConfig;
+  @property({ attribute: false }) public conditions: ConditionConfig = { ...DEFAULT_CONDITIONS };
+
+  @state() conditionIdx: number = -1;
+  @state() selectedDomain?: string;
+  @state() selectedEntity?: string;
+  @state() selectedMatchType?: TConditionMatchType;
+  @state() conditionValue?: string | number;
+  @state() conditionValid: boolean = true;
+
+  private _emitChange(next: ConditionConfig) {
+    this.conditions = next;
+    this.dispatchEvent(
+      new CustomEvent('value-changed', { detail: { value: next } })
+    );
+  }
+
+  render() {
+    const conditions: ConditionConfig = this.conditions || { ...DEFAULT_CONDITIONS };
+    return html`
+      <div class="header">
+        <span>${localize('ui.panel.options.conditions.header', this.hass)}:</span>
+        ${conditions.items.length
+        ? html`
+        <ha-dropdown
+          @wa-select=${this._conditionConfigOptionsClick}
+          @wa-after-hide=${(ev: Event) => { ((ev.target as HTMLElement).firstElementChild as HTMLElement).blur() }}
+          placement="bottom-end"
+        >
+          <ha-icon-button
+            slot="trigger"
+            .path=${mdiCog}
+          >
+          </ha-icon-button>
+          <ha-dropdown-item
+            ?disabled=${conditions.items.length < 2}
+            value="or"
+          >
+            <ha-icon
+              icon="mdi:check"
+              style="${conditions.type == TConditionLogicType.Or ? '' : 'visibility: hidden'}"
+            ></ha-icon>
+            ${localize('ui.panel.options.conditions.options.logic_or', this.hass)}
+          </ha-dropdown-item>
+          <ha-dropdown-item
+            ?disabled=${conditions.items.length < 2}
+            value="and"
+          >
+            <ha-icon
+              icon="mdi:check"
+              style="${conditions.type == TConditionLogicType.And ? '' : 'visibility: hidden'}"
+            ></ha-icon>
+            ${localize('ui.panel.options.conditions.options.logic_and', this.hass)}
+          </ha-dropdown-item>
+          <ha-dropdown-item value="track_changes">
+            <ha-icon
+              icon="mdi:check"
+              style="${conditions.track_changes ? '' : 'visibility: hidden'}"
+            ></ha-icon>
+            ${localize('ui.panel.options.conditions.options.track_changes', this.hass)}
+          </ha-dropdown-item>
+        </ha-dropdown>
+        `
+        : ''}
+      </div>
+      <scheduler-collapsible-group
+        ?disabled=${!this.conditionValid}
+        @openclose-changed=${this._updateActiveCondition}
+        .openedItem=${this.conditionIdx}
+      >
+        ${this.renderConditions()}
+      </scheduler-collapsible-group>
+
+      <div>
+        <ha-button appearance="plain"
+          @click=${this._conditionAddClick}
+        >
+          <ha-icon slot="start" icon="mdi:plus"></ha-icon>
+          ${localize('ui.panel.options.conditions.add_condition', this.hass)}
+        </ha-button>
+      </div>
+    `;
+  }
+
+  renderConditions() {
+    const conditions: ConditionConfig = this.conditions || { ...DEFAULT_CONDITIONS };
+    let items: Partial<Condition>[] = conditions.items;
+    if (this.conditionIdx == items.length) items = [...items, {}];
+
+    return items.map((condition, i) => {
+      const entityId = this.conditionIdx == i ? this.selectedEntity || condition.entity_id || "" : condition.entity_id || "";
+      const domain = this.conditionIdx == i ? this.selectedDomain || computeDomain(entityId) : computeDomain(entityId);
+      const selector = computeStatesForEntity(entityId || domain, this.hass, this.config.customize);
+
+      const matchTypes =
+        selector && selector.hasOwnProperty('number')
+          ? [TConditionMatchType.Above, TConditionMatchType.Below]
+          : [TConditionMatchType.Equal, TConditionMatchType.Unequal];
+
+      const matchTypeIcons = {
+        [TConditionMatchType.Equal]: 'mdi:equal',
+        [TConditionMatchType.Unequal]: 'mdi:not-equal-variant',
+        [TConditionMatchType.Above]: 'mdi:greater-than',
+        [TConditionMatchType.Below]: 'mdi:less-than',
+      };
+
+      const matchTypeValue = {
+        [TConditionMatchType.Equal]: 'ui.panel.options.conditions.types.equal_to',
+        [TConditionMatchType.Unequal]: 'ui.panel.options.conditions.types.unequal_to',
+        [TConditionMatchType.Above]: 'ui.panel.options.conditions.types.above',
+        [TConditionMatchType.Below]: 'ui.panel.options.conditions.types.below',
+      };
+
+      if (this.conditionIdx === i && !this.selectedMatchType) this.selectedMatchType = matchTypes[0];
+
+      return html`
+      <scheduler-collapsible-section idx="${i}">
+        <div slot="header">
+          ${condition.entity_id && condition.value !== undefined ? html`
+          <ha-icon slot="icon" icon="${computeEntityIcon(condition.entity_id, this.config.customize, this.hass)}"></ha-icon>
+          ${capitalizeFirstLetter(localize(matchTypeValue[condition.match_type!], this.hass, ['{entity}', '{value}'], [computeEntityDisplay(condition.entity_id, this.hass, this.config.customize) || '', formatSelectorDisplay(condition.value, selector, this.hass) ?? '']))}
+          ` : localize('ui.panel.options.conditions.add_condition', this.hass)}
+        </div>
+        <ha-dropdown
+          slot="contextMenu"
+          @wa-select=${(ev: CustomEvent) => this._conditionItemOptionsClick(ev, i)}
+          ?disabled=${!this.conditionValid && this.conditionIdx !== i && this.conditionIdx != -1}
+          placement="bottom-end"
+        >
+          <ha-icon-button
+            slot="trigger"
+            .path=${mdiDotsVertical}
+            ?disabled=${!this.conditionValid && this.conditionIdx !== i && this.conditionIdx != -1}
+          >
+          </ha-icon-button>
+          <ha-dropdown-item value="change_type">
+            <ha-icon icon="mdi:pencil"></ha-icon>
+            ${hassLocalize('ui.panel.lovelace.editor.card.conditional.change_type', this.hass)}
+          </ha-dropdown-item>
+          <ha-dropdown-item variant="danger" value="delete">
+            <ha-icon icon="mdi:delete"></ha-icon>
+            ${hassLocalize('ui.common.delete', this.hass)}
+          </ha-dropdown-item>
+        </ha-dropdown>
+
+        <div slot="content">
+          <scheduler-settings-row>
+            <span slot="heading">
+              ${hassLocalize('ui.components.selectors.selector.types.entity', this.hass)}
+            </span>
+            <scheduler-entity-picker
+              .hass=${this.hass}
+              .config=${this.config}
+              .domain=${domain}
+              @value-changed=${this._selectEntity}
+              .value=${this.conditionIdx == i ? asArray(this.selectedEntity) : asArray(condition.entity_id)}
+              ?multiple=${false}
+            >
+            </scheduler-entity-picker>
+          </scheduler-settings-row>
+
+          <scheduler-settings-row>
+            <span slot="heading">
+              ${capitalizeFirstLetter(localize(matchTypeValue[this.conditionIdx == i ? this.selectedMatchType! : condition.match_type!], this.hass, ['{entity}', '{value}'], ['', '']))}
+              <ha-dropdown
+                @wa-select=${this._selectMatchType}
+                @wa-after-hide=${(ev: Event) => { ((ev.target as HTMLElement).firstElementChild as HTMLElement).blur() }}
+              >
+                <ha-icon-button slot="trigger" .path=${mdiPencil}>
+                </ha-icon-button>
+                ${matchTypes.map(e => html`
+                  <ha-dropdown-item
+                    ?noninteractive=${this.conditionIdx == i ? this.selectedMatchType == e : condition.match_type == e}
+                    value="${e}"
+                  >
+                    <ha-icon icon="${matchTypeIcons[e]}"></ha-icon>
+                    ${capitalizeFirstLetter(localize(matchTypeValue[e], this.hass, ['{entity}', '{value}'], ['', '']))}
+                  </ha-dropdown-item>
+                `)}
+              </ha-dropdown>
+            </span>
+            <scheduler-combo-selector
+              .hass=${this.hass}
+              .config=${selector}
+              .value=${this.conditionIdx == i ? this.conditionValue : condition.value}
+              @value-changed=${this._conditionValueChanged}
+            >
+            </scheduler-combo-selector>
+          </scheduler-settings-row>
+        </div>
+      </scheduler-collapsible-section>
+    `}
+    );
+  }
+
+  _updateActiveCondition(ev: CustomEvent) {
+    const idx = ev.detail.item;
+    if (idx < 0) {
+      this.conditionIdx = -1;
+      return;
+    }
+    if (idx === this.conditionIdx) return;
+    this.conditionIdx = idx;
+    const condition = (this.conditions?.items || [])[idx];
+    this.selectedEntity = condition ? condition.entity_id : undefined;
+    this.selectedMatchType = condition ? condition.match_type : undefined;
+    this.conditionValue = condition ? condition.value : undefined;
+  }
+
+  _conditionItemOptionsClick(ev: CustomEvent, idx: number) {
+    const option: 'change_type' | 'delete' = ev.detail.item.value;
+    switch (option) {
+      case "change_type":
+        this._showConditionDialog(ev)
+          .then(res => {
+            if (!res) return;
+            this.conditionIdx = idx;
+            this.selectedDomain = res;
+            this.selectedEntity = undefined;
+            this.selectedMatchType = undefined;
+            this.conditionValue = undefined;
+            this.conditionValid = false;
+          });
+        break;
+      case "delete":
+        const items: Condition[] = (this.conditions?.items || []).filter((_e, i) => i !== idx);
+        this._emitChange({ ...(this.conditions || DEFAULT_CONDITIONS), items });
+        if (idx === this.conditionIdx) this.conditionIdx = -1;
+        else if (this.conditionIdx !== undefined && idx < this.conditionIdx) this.conditionIdx = this.conditionIdx - 1;
+        this.conditionValid = true;
+        break;
+    }
+  }
+
+  _selectMatchType(ev: CustomEvent) {
+    const value: TConditionMatchType = ev.detail.item.value;
+    this.selectedMatchType = value;
+    this._validateCondition();
+  }
+
+  _conditionValueChanged(ev: CustomEvent) {
+    this.conditionValue = ev.detail.value;
+    this._validateCondition();
+  }
+
+  async _showConditionDialog(ev: Event) {
+    return new Promise<string | null>(resolve => {
+      const params: DialogSelectConditionParams = {
+        cancel: () => resolve(null),
+        confirm: (out: string) => resolve(out),
+        domain: undefined,
+        cardConfig: this.config
+      };
+
+      fireEvent(ev.target as HTMLElement, 'show-dialog', {
+        dialogTag: 'dialog-select-condition',
+        dialogImport: () => import('../dialogs/dialog-select-condition'),
+        dialogParams: params,
+      });
+    })
+  }
+
+  _selectEntity(ev: CustomEvent) {
+    const entity = ev.detail.value as string[] | undefined;
+    this.selectedEntity = entity ? entity.pop() : undefined;
+    if (this.selectedEntity) {
+      const selector = computeStatesForEntity(this.selectedEntity, this.hass, this.config.customize);
+      const matchTypes =
+        selector && selector.hasOwnProperty('number')
+          ? [TConditionMatchType.Above, TConditionMatchType.Below]
+          : [TConditionMatchType.Equal, TConditionMatchType.Unequal];
+      if (!this.selectedMatchType || !matchTypes.includes(this.selectedMatchType)) this.selectedMatchType = matchTypes[0];
+    }
+    this._validateCondition();
+  }
+
+  _validateCondition() {
+    this.conditionValid = false;
+    if (!this.selectedEntity || !isDefined(this.conditionValue) || !this.selectedMatchType || this.conditionIdx === undefined) return;
+    const selector = computeStatesForEntity(this.selectedEntity, this.hass, this.config.customize);
+    if (!validateSelectorValue(this.conditionValue, selector)) return;
+    this.conditionValid = true;
+    const condition: Condition = {
+      entity_id: this.selectedEntity,
+      match_type: this.selectedMatchType,
+      value: this.conditionValue,
+      attribute: 'state'
+    };
+    const baseItems = (this.conditions?.items || []).slice();
+    baseItems[this.conditionIdx] = condition;
+    this._emitChange({ ...(this.conditions || DEFAULT_CONDITIONS), items: baseItems });
+  }
+
+  _conditionAddClick(ev: Event) {
+    this._showConditionDialog(ev)
+      .then(res => {
+        if (!res) return;
+        this.conditionIdx = (this.conditions?.items || []).length;
+        this.selectedDomain = res;
+        this.selectedEntity = undefined;
+        this.selectedMatchType = undefined;
+        this.conditionValue = undefined;
+        this.conditionValid = false;
+      });
+  }
+
+  _conditionConfigOptionsClick(ev: CustomEvent) {
+    let conditionConfig: ConditionConfig = { ...(this.conditions || DEFAULT_CONDITIONS) };
+    const option: 'and' | 'or' | 'track_changes' = ev.detail.item.value;
+    switch (option) {
+      case 'or':
+        if (conditionConfig.type == TConditionLogicType.Or) return;
+        conditionConfig = { ...conditionConfig, type: TConditionLogicType.Or };
+        break;
+      case 'and':
+        if (conditionConfig.type == TConditionLogicType.And) return;
+        conditionConfig = { ...conditionConfig, type: TConditionLogicType.And };
+        break;
+      case 'track_changes':
+        conditionConfig = { ...conditionConfig, track_changes: !conditionConfig.track_changes };
+        break;
+    }
+    this._emitChange(conditionConfig);
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: block;
+      }
+      ha-icon-button {
+        align-self: center;
+      }
+      ha-dropdown-item[disabled] ha-icon {
+        color: var(--disabled-text-color);
+      }
+      ha-dropdown-item[noninteractive] {
+        background-color: rgba(var(--rgb-primary-color), 0.12);
+        color: var(--sidebar-selected-text-color);
+      }
+      ha-dropdown-item[noninteractive] ha-icon {
+        color: var(--sidebar-selected-text-color);
+      }
+      .header {
+        display: flex;
+        margin-top: 5px;
+        width: 100%;
+        align-items: flex-end;
+        justify-content: space-between;
+        padding-bottom: 4px;
+      }
+      .header > * {
+        display: flex;
+      }
+      .header ha-dropdown {
+        margin-bottom: -10px;
+      }
+    `;
+  }
+}

--- a/src/dialogs/scheduler-main-panel.ts
+++ b/src/dialogs/scheduler-main-panel.ts
@@ -1,7 +1,7 @@
 import { mdiChevronLeft, mdiChevronRight, mdiDotsVertical, mdiPencil, mdiShapeRectanglePlus, mdiTrashCanOutline } from "@mdi/js";
 import { CSSResultGroup, LitElement, PropertyValues, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
-import { Action, CardConfig, EditorMode, Schedule, ScheduleEntry, TWeekday, Time, Timeslot } from "../types";
+import { Action, CardConfig, ConditionConfig, EditorMode, Schedule, ScheduleEntry, TConditionLogicType, TWeekday, Time, Timeslot } from "../types";
 import { actionConfig } from "../data/actions/action_config";
 import { formatWeekdayDisplay } from "../data/days";
 import { defaultSelectorValue } from "../data/selectors/default_selector_value";
@@ -38,6 +38,7 @@ import '../dialogs/dialog-select-action';
 import '../components/scheduler-collapsible-section';
 import '../components/scheduler-settings-row';
 import '../components/scheduler-combo-selector';
+import '../components/scheduler-conditions-editor';
 
 @customElement('scheduler-main-panel')
 export class SchedulerMainPanel extends LitElement {
@@ -194,7 +195,37 @@ export class SchedulerMainPanel extends LitElement {
 
       ${localize('ui.panel.editor.action', this.hass)}:
       ${this._renderActionConfig()}
+      ${this._renderConditionsConfig()}
     `;
+  }
+
+  _renderConditionsConfig() {
+    if (this.selectedEntry === null || this.selectedSlot === null) return html``;
+    const slot: Timeslot = this.schedule.entries[this.selectedEntry].slots[this.selectedSlot];
+    // Only show the conditions section when this timeslot has an action;
+    // conditions on an empty (filler) timeslot have no effect.
+    if (!slot || !slot.actions.length) return html``;
+
+    const conditions: ConditionConfig = slot.conditions || {
+      type: TConditionLogicType.Or,
+      items: [],
+      track_changes: false,
+    };
+
+    return html`
+      <scheduler-conditions-editor
+        .hass=${this.hass}
+        .config=${this.config}
+        .conditions=${conditions}
+        @value-changed=${this._conditionsChanged}
+      >
+      </scheduler-conditions-editor>
+    `;
+  }
+
+  _conditionsChanged(ev: CustomEvent) {
+    const value: ConditionConfig = ev.detail.value;
+    this._updateSlot({ conditions: value });
   }
 
   _renderActionConfig() {

--- a/src/dialogs/scheduler-options-panel.ts
+++ b/src/dialogs/scheduler-options-panel.ts
@@ -120,8 +120,8 @@ export class SchedulerOptionsPanel extends LitElement {
             ${localize('ui.panel.options.conditions.options.logic_and', this.hass)}
           </ha-dropdown-item>
           <ha-dropdown-item value="track_changes">
-            <ha-icon 
-              icon="mdi:check" 
+            <ha-icon
+              icon="mdi:check"
               style="${this.schedule.entries[0].slots[0].conditions.track_changes ? '' : 'visibility: hidden'}"
             ></ha-icon>
             ${localize('ui.panel.options.conditions.options.track_changes', this.hass)}


### PR DESCRIPTION
## Summary

Currently, the conditions configured on a schedule are applied to every action in every timeslot: the same condition gates both the "start" action and the "stop" action of a schedule. This makes some common scenarios impossible.

Concrete example — automatic garden irrigation:

- Slot `07:20 → 07:30`: action *turn irrigation ON*
- Slot `07:30 → next day`: action *turn irrigation OFF*

I want the **start** to fire only when soil moisture is below a threshold, but the **stop** must always run regardless of soil moisture, so the irrigation never stays on indefinitely. With the current global-conditions UI this is impossible: the same condition is evaluated for the whole schedule, and either both actions are gated or none of them is.

This PR allows conditions to be configured **per individual timeslot/action**, in addition to keeping the existing global conditions UI.

## Changes

- New reusable component `scheduler-conditions-editor` (`src/components/scheduler-conditions-editor.ts`) that encapsulates the conditions UI (entity/value pickers, AND/OR logic, *Re-evaluate when conditions change*, add/edit/delete). It operates on a single `ConditionConfig` and emits `value-changed`.
- The new component is rendered inside `scheduler-main-panel` directly below the action of the currently selected timeslot. It is hidden for empty/filler timeslots (no action), since conditions on those would have no effect.
- The existing global conditions section in `scheduler-options-panel` is left untouched, so users can still set the same conditions for the whole schedule with one shortcut, and per-slot conditions act as overrides.

## Data model / backend

No data-model or backend changes are needed:

- `Timeslot.conditions: ConditionConfig` already exists on the frontend.
- `exportSchedule`/`parseTimeslot` in `src/data/store/save_schedule.ts` and `convertLegacySchedule` in `src/data/store/convert_legacy_schedule.ts` already serialize/deserialize `conditions`, `condition_type` and `track_conditions` **per timeslot** in the websocket payload to/from the `scheduler` integration.

In other words, the per-timeslot capability was already in the wire protocol; this PR only exposes it in the UI.

## Backward compatibility

- Existing schedules load unchanged: the global UI continues to write the same `ConditionConfig` to all slots, so legacy "same condition everywhere" behaviour is preserved.
- Once a user edits the conditions of one specific timeslot from the new per-slot UI, that timeslot diverges from the others, which is the intended new behaviour.
- The global UI reads from `slots[0].conditions` for display, which matches the legacy behaviour.

## Screenshots

The new "Conditions" section appears under the action when a timeslot with an action is selected (it sits in the same place where the existing global section is in the settings menu):

<img width="571" height="693" alt="Screenshot 2026-05-13 alle 23 29 55" src="https://github.com/user-attachments/assets/5c654205-e6f7-404e-b9ff-5695e0f831a5" />


## Notes

- I noticed that the build pipeline as documented in `CONTRIBUTING.md` is currently broken on a clean checkout (`npm run lint` references `eslint`, which is not in `package.json` and whose plugins are not installed; `rollup-plugin-typescript2 0.31.2` also fails because its default `include` pattern uses extglob syntax that newer `@rollup/pluginutils` does not enable). I kept these fixes out of this PR to keep the diff focused, but I can open a separate PR if useful.