### PR TITLE
build: update rollup and plugins for modern node

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',  // Specifies the ESLint parser
   extends: [
     'plugin:@typescript-eslint/recommended',  // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    'prettier/@typescript-eslint',  // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    'eslint-config-prettier',  // Disables ESLint rules that would conflict with prettier
     'plugin:prettier/recommended',  // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
   parserOptions: {
@@ -18,6 +18,8 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/ban-ts-ignore": "off"
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-empty-object-type": "off"
   }
 };

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: Build
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   release:
     types: [published]
 
@@ -9,9 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: JasonEtco/upload-to-release@master
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: JasonEtco/upload-to-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/package.json
+++ b/package.json
@@ -26,22 +26,25 @@
     "fecha": "^4.2.3",
     "home-assistant-js-websocket": "^8.0.1",
     "lit": "^2.7.4",
-    "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-ignore": "^1.0.10",
-    "rollup-plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-serve": "^1.0.1",
-    "rollup-plugin-terser": "^5.1.2",
-    "rollup-plugin-typescript2": "^0.31.1",
-    "rollup-plugin-uglify": "^6.0.3",
-    "rollup-plugin-visualizer": "^4.2.0",
     "typescript": "^5.8.3"
   },
   "devDependencies": {
     "@parcel/transformer-inline-string": "^2.8.3",
+    "@rollup/plugin-alias": "^5.1.1",
+    "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-dynamic-import-vars": "^2.1.2",
-    "parcel": "^2.8.3"
+    "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-typescript": "^12.1.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "parcel": "^2.8.3",
+    "prettier": "^3.0.0",
+    "rollup": "^4.0.0",
+    "rollup-plugin-visualizer": "^5.12.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,20 @@
-import nodeResolve from 'rollup-plugin-node-resolve';
-import typescript from 'rollup-plugin-typescript2';
-import json from 'rollup-plugin-json';
-import { terser } from 'rollup-plugin-terser';
-import commonjs from 'rollup-plugin-commonjs';
-import visualizer from 'rollup-plugin-visualizer';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+import alias from '@rollup/plugin-alias';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 
 const plugins = [
+  alias({
+    entries: [
+      { find: 'lit/decorators', replacement: 'lit/decorators.js' },
+      { find: 'lit/directives/style-map', replacement: 'lit/directives/style-map.js' },
+      { find: 'lit/directives/unsafe-html', replacement: 'lit/directives/unsafe-html.js' },
+    ]
+  }),
   nodeResolve(),
   commonjs({
     include: 'node_modules/**',
@@ -24,6 +32,7 @@ export default [
       dir: 'dist',
       format: 'iife',
       sourcemap: false,
+      name: 'SchedulerCard',
     },
     plugins: [...plugins],
     context: 'window',

--- a/src/lib/selector.ts
+++ b/src/lib/selector.ts
@@ -20,7 +20,7 @@ export enum supportedSelectors {
 }
 
 export interface BooleanSelector {
-  // eslint-disable-next-line @typescript-eslint/ban-types
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   boolean: {} | null;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "esnext",
     "moduleResolution": "node",
     "lib": [
-      "es2017",
+      "es2019",
+      "es2020.intl",
+      "es2021.intl",
       "dom",
       "dom.iterable"
     ],


### PR DESCRIPTION
The current build toolchain (Rollup 1.x + deprecated `rollup-plugin-*` packages) can no longer build the project on modern Node versions. Running `npm run build` or `npm run rollup` fails with `rollup-plugin-typescript2` not transforming `.ts` files.

This PR updates the toolchain to current versions so `npm run build` works again.

### Changes

- Replace deprecated plugins with official `@rollup/plugin-*` packages:
  - `rollup-plugin-node-resolve` → `@rollup/plugin-node-resolve`
  - `rollup-plugin-commonjs` → `@rollup/plugin-commonjs`
  - `rollup-plugin-json` → `@rollup/plugin-json`
  - `rollup-plugin-terser` → `@rollup/plugin-terser`
  - `rollup-plugin-typescript2` → `@rollup/plugin-typescript`
- Add `@rollup/plugin-alias` to map `lit/decorators` → `lit/decorators.js` (required by Lit's package exports).
- Update `rollup` to v4.
- Update `tsconfig.json` libs to `es2019` / `es2020.intl` / `es2021.intl` so TypeScript recognizes `Array.prototype.flat`, `Object.fromEntries`, and `Intl.RelativeTimeFormat`.
- Update `.eslintrc.js` for current `@typescript-eslint` defaults and replace the removed `prettier/@typescript-eslint` preset.
- Update `.github/workflows/build.yaml` to run `npm run build` on every PR and push to `main`, preventing future build regressions.

### Verification

`npm run build` now completes successfully.
